### PR TITLE
Change source of maplibre-gl-inspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ VersaTiles Frontend utilizes several external resources and libraries, including
 - Fonts from [VersaTiles Fonts](https://github.com/versatiles-org/versatiles-fonts)
 - Styles and sprites from [VersaTiles Style](https://github.com/versatiles-org/versatiles-style)
 - MapLibre GL JS from [MapLibre GL JS GitHub](https://github.com/maplibre/maplibre-gl-js)
-- MapLibre GL Inspect from [MapLibre GL Inspect GitHub](https://github.com/acalcutt/maplibre-gl-inspect)
+- MapLibre GL Inspect from [MapLibre GL Inspect GitHub](https://github.com/maplibre/maplibre-gl-inspect)
 
 Note: Some external dependencies may require separate installations or configurations.

--- a/frontends/frontend-minimal/index.html
+++ b/frontends/frontend-minimal/index.html
@@ -12,7 +12,7 @@
 	<script src="assets/mapdesigner/mapdesigner-control.js"></script>
 	<link href="assets/mapdesigner/mapdesigner-control.css" rel="stylesheet">
 
-	<script src="assets/maplibre-gl-inspect/maplibre-gl-inspect.min.js"></script>
+	<script src="assets/maplibre-gl-inspect/maplibre-gl-inspect.js"></script>
 	<link href="assets/maplibre-gl-inspect/maplibre-gl-inspect.css" rel="stylesheet">
 
 	<script src="assets/styles/versatiles-style.js"></script>

--- a/frontends/frontend/index.html
+++ b/frontends/frontend/index.html
@@ -12,7 +12,7 @@
 	<script src="assets/mapdesigner/mapdesigner-control.js"></script>
 	<link href="assets/mapdesigner/mapdesigner-control.css" rel="stylesheet">
 
-	<script src="assets/maplibre-gl-inspect/maplibre-gl-inspect.min.js"></script>
+	<script src="assets/maplibre-gl-inspect/maplibre-gl-inspect.js"></script>
 	<link href="assets/maplibre-gl-inspect/maplibre-gl-inspect.css" rel="stylesheet">
 
 	<script src="assets/styles/versatiles-style.js"></script>

--- a/src/lib/assets.test.ts
+++ b/src/lib/assets.test.ts
@@ -38,7 +38,7 @@ describe('getAssets', () => {
 		const glrvCalls = jest.mocked(getLatestReleaseVersion).mock.calls;
 		glrvCalls.sort((a, b) => a[0].localeCompare(b[0]) || a[1].localeCompare(b[1]));
 		expect(glrvCalls).toStrictEqual([
-			['acalcutt', 'maplibre-gl-inspect'],
+			['maplibre', 'maplibre-gl-inspect'],
 			['maplibre', 'maplibre-gl-js'],
 			['versatiles-org', 'versatiles-fonts'],
 			['versatiles-org', 'versatiles-style'],
@@ -47,8 +47,8 @@ describe('getAssets', () => {
 		const curlResults = jest.mocked(Curl).mock.results.map(e => (e.value as { url: string }).url);
 		curlResults.sort();
 		expect(curlResults).toStrictEqual([
-			'https://github.com/acalcutt/maplibre-gl-inspect/releases/download/v1.2.3/maplibre-gl-inspect.css',
-			'https://github.com/acalcutt/maplibre-gl-inspect/releases/download/v1.2.3/maplibre-gl-inspect.min.js',
+			'https://github.com/maplibre/maplibre-gl-inspect/releases/download/v1.2.3/maplibre-gl-inspect.css',
+			'https://github.com/maplibre/maplibre-gl-inspect/releases/download/v1.2.3/maplibre-gl-inspect.js',
 			'https://github.com/maplibre/maplibre-gl-js/releases/download/v1.2.3/dist.zip',
 			'https://github.com/versatiles-org/versatiles-fonts/releases/download/v1.2.3/fonts.tar.gz',
 			'https://github.com/versatiles-org/versatiles-style/releases/download/v1.2.3/sprites.tar.gz',

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -85,13 +85,10 @@ export function getAssets(fileSystem: FileSystem): PromiseFunction {
 	 */
 	function addMaplibreInspect(): PromiseFunction {
 		const folder = 'assets/maplibre-gl-inspect';
-		const label = notes.add('[MapLibre GL Inspect](https://github.com/acalcutt/maplibre-gl-inspect)');
 		return PromiseFunction.wrapAsync('add maplibre-gl-inspect', 1, async () => {
-			const version = await getLatestReleaseVersion('acalcutt', 'maplibre-gl-inspect');
-			label.setVersion(version);
-			const baseUrl = `https://github.com/acalcutt/maplibre-gl-inspect/releases/download/v${version}/`;
+			const baseUrl = `https://unpkg.com/@maplibre/maplibre-gl-inspect@latest/dist/`;
 			await Promise.all([
-				new Curl(fileSystem, baseUrl + 'maplibre-gl-inspect.min.js').save(join(folder, 'maplibre-gl-inspect.min.js')),
+				new Curl(fileSystem, baseUrl + 'maplibre-gl-inspect.js').save(join(folder, 'maplibre-gl-inspect.js')),
 				new Curl(fileSystem, baseUrl + 'maplibre-gl-inspect.css').save(join(folder, 'maplibre-gl-inspect.css')),
 			]);
 		});


### PR DESCRIPTION
Change the source of maplibre-gl-inspect as https://github.com/acalcutt/maplibre-gl-inspect no longer works. I used https://unpkg.com because I think this is easier/better. Also, I  have not found a minified version today.