### PR TITLE
feat: Add basix nix shell

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,14 @@
+{
+  pkgs ? import <nixpkgs> { },
+}:
+pkgs.mkShell {
+  name = "dev-environment";
+  buildInputs = [
+    pkgs.nodejs
+  ];
+shellHook = ''
+    echo "Start deploying..."
+  '';
+}
+
+


### PR DESCRIPTION
Honestly I am very new to both Nix and Versatiles so please tell me if this is unhelpful but this adds a basic nix-shell config that allows to build the frontend.

**Usage**

```bash
$ nix-shell
[nix-shell] $ npm install
[nix-shell] $npm run-build
[nix-shell] $ ls release/
frontend.br.tar          frontend-minimal.tar.gz  frontend-rust.tar.gz  notes.md
frontend-minimal.br.tar  frontend-rust.br.tar     frontend.tar.gz
```