### PR TITLE
Fix code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "classic-level": "^1.4.1",
+        "escape-html": "^1.0.3",
         "express": "^4.21.0",
         "ignore": "^6.0.2",
         "supports-color": "^9.4.0",
@@ -21,6 +22,7 @@
         "versatiles-frontend": "src/index.ts"
       },
       "devDependencies": {
+        "@types/escape-html": "^1.0.4",
         "@types/express": "^5.0.0",
         "@types/jest": "^29.5.13",
         "@types/node": "^22.7.4",
@@ -2019,6 +2021,13 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/escape-html": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/escape-html/-/escape-html-1.0.4.tgz",
+      "integrity": "sha512-qZ72SFTgUAZ5a7Tj6kf2SHLetiH5S6f8G5frB2SPQ3EyF02kxdyBFf4Tz4banE3xCgGnKgWLt//a6VuYHKYJTg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "supports-color": "^9.4.0",
     "tar-stream": "^3.1.7",
     "tsx": "^4.19.1",
-    "unzipper": "^0.12.3"
+    "unzipper": "^0.12.3",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -21,15 +21,16 @@
   "license": "MIT",
   "dependencies": {
     "classic-level": "^1.4.1",
+    "escape-html": "^1.0.3",
     "express": "^4.21.0",
     "ignore": "^6.0.2",
     "supports-color": "^9.4.0",
     "tar-stream": "^3.1.7",
     "tsx": "^4.19.1",
-    "unzipper": "^0.12.3",
-    "escape-html": "^1.0.3"
+    "unzipper": "^0.12.3"
   },
   "devDependencies": {
+    "@types/escape-html": "^1.0.4",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.13",
     "@types/node": "^22.7.4",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,4 +1,5 @@
 import express from 'express';
+import escapeHtml from 'escape-html';
 import type { FileSystem } from '../lib/file_system';
 import type { Express } from 'express';
 import { resolve } from 'node:url';
@@ -72,7 +73,7 @@ export class Server {
 			void tryProxy(req.path).then(value => {
 				if (value) return;
 				// Respond with 404 if the file was not found in the file system and no proxy rule matched.
-				res.status(404).end(`path "${req.path}" not found.`);
+				res.status(404).end(`path "${escapeHtml(req.path)}" not found.`);
 			});
 
 			/**


### PR DESCRIPTION
Fixes [https://github.com/versatiles-org/versatiles-frontend/security/code-scanning/2](https://github.com/versatiles-org/versatiles-frontend/security/code-scanning/2)

To fix the reflected cross-site scripting vulnerability, we need to sanitize the user input before incorporating it into the response. The best way to do this is by using a well-known library for escaping HTML, such as `escape-html`. This will ensure that any potentially malicious characters in the `req.path` are properly escaped, preventing XSS attacks.

- **General Fix:** Use contextual output encoding/escaping before writing user input to the response.
- **Detailed Fix:** Import the `escape-html` library and use it to sanitize `req.path` before including it in the response.
- **Specific Changes:** Modify the file `src/server/server.ts` to include the `escape-html` library and apply it to the `req.path` on line 75.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
